### PR TITLE
Simplified house tp commands for ct-grimoire_actions.txt

### DIFF
--- a/config/fancymenu/customization/ct-grimoire_actions.txt
+++ b/config/fancymenu/customization/ct-grimoire_actions.txt
@@ -240,7 +240,7 @@ element {
 
 element {
   button_element_executable_block_identifier = 02aeb7b0-3162-4017-9371-4db48822388c-1753140079483
-  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_{"placeholder":"scoreboard_score","values":{"player":"{"placeholder":"getvariable","values":{"name":"player_{"placeholder":"getvariable","values":{"name":"editing_player"}}"}}","objective":"game_data"}}]
+  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_1]
   [executable_block:02aeb7b0-3162-4017-9371-4db48822388c-1753140079483][type:generic] = [executables:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598;]
   restartbackgroundanimations = true
   nine_slice_custom_background = false
@@ -568,7 +568,7 @@ element {
 
 element {
   button_element_executable_block_identifier = 02aeb7b0-3162-4017-9371-4db48822388c-1753140079483
-  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_{"placeholder":"scoreboard_score","values":{"player":"{"placeholder":"getvariable","values":{"name":"player_{"placeholder":"getvariable","values":{"name":"editing_player"}}"}}","objective":"game_data"}}]
+  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_2]
   [executable_block:02aeb7b0-3162-4017-9371-4db48822388c-1753140079483][type:generic] = [executables:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598;]
   restartbackgroundanimations = true
   nine_slice_custom_background = false
@@ -896,7 +896,7 @@ element {
 
 element {
   button_element_executable_block_identifier = 02aeb7b0-3162-4017-9371-4db48822388c-1753140079483
-  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_{"placeholder":"scoreboard_score","values":{"player":"{"placeholder":"getvariable","values":{"name":"player_{"placeholder":"getvariable","values":{"name":"editing_player"}}"}}","objective":"game_data"}}]
+  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_3]
   [executable_block:02aeb7b0-3162-4017-9371-4db48822388c-1753140079483][type:generic] = [executables:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598;]
   restartbackgroundanimations = true
   nine_slice_custom_background = false
@@ -1224,7 +1224,7 @@ element {
 
 element {
   button_element_executable_block_identifier = 02aeb7b0-3162-4017-9371-4db48822388c-1753140079483
-  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_{"placeholder":"scoreboard_score","values":{"player":"{"placeholder":"getvariable","values":{"name":"player_{"placeholder":"getvariable","values":{"name":"editing_player"}}"}}","objective":"game_data"}}]
+  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_4]
   [executable_block:02aeb7b0-3162-4017-9371-4db48822388c-1753140079483][type:generic] = [executables:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598;]
   restartbackgroundanimations = true
   nine_slice_custom_background = false
@@ -1552,7 +1552,7 @@ element {
 
 element {
   button_element_executable_block_identifier = 02aeb7b0-3162-4017-9371-4db48822388c-1753140079483
-  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_{"placeholder":"scoreboard_score","values":{"player":"{"placeholder":"getvariable","values":{"name":"player_{"placeholder":"getvariable","values":{"name":"editing_player"}}"}}","objective":"game_data"}}]
+  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_5]
   [executable_block:02aeb7b0-3162-4017-9371-4db48822388c-1753140079483][type:generic] = [executables:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598;]
   restartbackgroundanimations = true
   nine_slice_custom_background = false
@@ -1880,7 +1880,7 @@ element {
 
 element {
   button_element_executable_block_identifier = 02aeb7b0-3162-4017-9371-4db48822388c-1753140079483
-  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_{"placeholder":"scoreboard_score","values":{"player":"{"placeholder":"getvariable","values":{"name":"player_{"placeholder":"getvariable","values":{"name":"editing_player"}}"}}","objective":"game_data"}}]
+  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_6]
   [executable_block:02aeb7b0-3162-4017-9371-4db48822388c-1753140079483][type:generic] = [executables:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598;]
   restartbackgroundanimations = true
   nine_slice_custom_background = false
@@ -2208,7 +2208,7 @@ element {
 
 element {
   button_element_executable_block_identifier = 02aeb7b0-3162-4017-9371-4db48822388c-1753140079483
-  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_{"placeholder":"scoreboard_score","values":{"player":"{"placeholder":"getvariable","values":{"name":"player_{"placeholder":"getvariable","values":{"name":"editing_player"}}"}}","objective":"game_data"}}]
+  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_7]
   [executable_block:02aeb7b0-3162-4017-9371-4db48822388c-1753140079483][type:generic] = [executables:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598;]
   restartbackgroundanimations = true
   nine_slice_custom_background = false
@@ -2536,7 +2536,7 @@ element {
 
 element {
   button_element_executable_block_identifier = 02aeb7b0-3162-4017-9371-4db48822388c-1753140079483
-  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_{"placeholder":"scoreboard_score","values":{"player":"{"placeholder":"getvariable","values":{"name":"player_{"placeholder":"getvariable","values":{"name":"editing_player"}}"}}","objective":"game_data"}}]
+  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_8]
   [executable_block:02aeb7b0-3162-4017-9371-4db48822388c-1753140079483][type:generic] = [executables:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598;]
   restartbackgroundanimations = true
   nine_slice_custom_background = false
@@ -2864,7 +2864,7 @@ element {
 
 element {
   button_element_executable_block_identifier = 02aeb7b0-3162-4017-9371-4db48822388c-1753140079483
-  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_{"placeholder":"scoreboard_score","values":{"player":"{"placeholder":"getvariable","values":{"name":"player_{"placeholder":"getvariable","values":{"name":"editing_player"}}"}}","objective":"game_data"}}]
+  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_9]
   [executable_block:02aeb7b0-3162-4017-9371-4db48822388c-1753140079483][type:generic] = [executables:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598;]
   restartbackgroundanimations = true
   nine_slice_custom_background = false
@@ -3192,7 +3192,7 @@ element {
 
 element {
   button_element_executable_block_identifier = 02aeb7b0-3162-4017-9371-4db48822388c-1753140079483
-  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_{"placeholder":"scoreboard_score","values":{"player":"{"placeholder":"getvariable","values":{"name":"player_{"placeholder":"getvariable","values":{"name":"editing_player"}}"}}","objective":"game_data"}}]
+  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_10]
   [executable_block:02aeb7b0-3162-4017-9371-4db48822388c-1753140079483][type:generic] = [executables:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598;]
   restartbackgroundanimations = true
   nine_slice_custom_background = false
@@ -3520,7 +3520,7 @@ element {
 
 element {
   button_element_executable_block_identifier = 02aeb7b0-3162-4017-9371-4db48822388c-1753140079483
-  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_{"placeholder":"scoreboard_score","values":{"player":"{"placeholder":"getvariable","values":{"name":"player_{"placeholder":"getvariable","values":{"name":"editing_player"}}"}}","objective":"game_data"}}]
+  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_11]
   [executable_block:02aeb7b0-3162-4017-9371-4db48822388c-1753140079483][type:generic] = [executables:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598;]
   restartbackgroundanimations = true
   nine_slice_custom_background = false
@@ -3848,7 +3848,7 @@ element {
 
 element {
   button_element_executable_block_identifier = 02aeb7b0-3162-4017-9371-4db48822388c-1753140079483
-  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_{"placeholder":"scoreboard_score","values":{"player":"{"placeholder":"getvariable","values":{"name":"player_{"placeholder":"getvariable","values":{"name":"editing_player"}}"}}","objective":"game_data"}}]
+  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_12]
   [executable_block:02aeb7b0-3162-4017-9371-4db48822388c-1753140079483][type:generic] = [executables:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598;]
   restartbackgroundanimations = true
   nine_slice_custom_background = false
@@ -4176,7 +4176,7 @@ element {
 
 element {
   button_element_executable_block_identifier = 02aeb7b0-3162-4017-9371-4db48822388c-1753140079483
-  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_{"placeholder":"scoreboard_score","values":{"player":"{"placeholder":"getvariable","values":{"name":"player_{"placeholder":"getvariable","values":{"name":"editing_player"}}"}}","objective":"game_data"}}]
+  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_13]
   [executable_block:02aeb7b0-3162-4017-9371-4db48822388c-1753140079483][type:generic] = [executables:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598;]
   restartbackgroundanimations = true
   nine_slice_custom_background = false
@@ -4504,7 +4504,7 @@ element {
 
 element {
   button_element_executable_block_identifier = 02aeb7b0-3162-4017-9371-4db48822388c-1753140079483
-  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_{"placeholder":"scoreboard_score","values":{"player":"{"placeholder":"getvariable","values":{"name":"player_{"placeholder":"getvariable","values":{"name":"editing_player"}}"}}","objective":"game_data"}}]
+  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_14]
   [executable_block:02aeb7b0-3162-4017-9371-4db48822388c-1753140079483][type:generic] = [executables:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598;]
   restartbackgroundanimations = true
   nine_slice_custom_background = false
@@ -4832,7 +4832,7 @@ element {
 
 element {
   button_element_executable_block_identifier = 02aeb7b0-3162-4017-9371-4db48822388c-1753140079483
-  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_{"placeholder":"scoreboard_score","values":{"player":"{"placeholder":"getvariable","values":{"name":"player_{"placeholder":"getvariable","values":{"name":"editing_player"}}"}}","objective":"game_data"}}]
+  [executable_action_instance:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598][action_type:sendmessage] = /tp @s @e[type=marker,limit=1,tag=house_15]
   [executable_block:02aeb7b0-3162-4017-9371-4db48822388c-1753140079483][type:generic] = [executables:87e3b156-0547-40d9-9680-bbe498fa04be-1753144431598;]
   restartbackgroundanimations = true
   nine_slice_custom_background = false


### PR DESCRIPTION
Grimoire buttons and houses are both tied to the seat, so the id does not need to be determined based on player. It can just be static for each button.

These commands can be used to add house markers to the map:

summon minecraft:marker 83.5 77 109.5 {Tags:["house_1"]}
summon minecraft:marker 71.5 76 126.5 {Tags:["house_2"]}
summon minecraft:marker 49.5 76 114.5 {Tags:["house_3"]}
summon minecraft:marker 98.5 84 25.5 {Tags:["house_4"]}
summon minecraft:marker 109.5 81 14.5 {Tags:["house_5"]}
summon minecraft:marker 123.5 80 10.5 {Tags:["house_6"]}
summon minecraft:marker 144.5 79 16.5 {Tags:["house_7"]}
summon minecraft:marker 165.5 72 35.5 {Tags:["house_8"]}
summon minecraft:marker 178.5 73 45.5 {Tags:["house_9"]}
summon minecraft:marker 184.5 71 61.5 {Tags:["house_10"]}
summon minecraft:marker 154.5 71 81.5 {Tags:["house_11"]}
summon minecraft:marker 168.5 71 87.5 {Tags:["house_12"]}
summon minecraft:marker 182.5 72 97.5 {Tags:["house_13"]}
summon minecraft:marker 171.5 72 109.5 {Tags["house_14"]}
summon minecraft:marker 153.5 73 115.5 {Tags:["house_15"]}

I might be overlooking something that this breaks somewhere else in the pack and I don't actually know if you're open to PR contributions like this so feel free to tell me to buzz off but I like the pack and wanted to contribute