### PR TITLE
Display user keybinds instead of the default ones in messages

### DIFF
--- a/resources/datapack/required/ct/data/ct/function/admin/setup/set_from_menu.mcfunction
+++ b/resources/datapack/required/ct/data/ct/function/admin/setup/set_from_menu.mcfunction
@@ -160,5 +160,5 @@ execute if score gnome role_list matches 1 run data modify storage ct:roles role
 execute if score bishop role_list matches 1 run data modify storage ct:roles roles insert 0 value {id:516,name:bishop}
 execute if score voudon role_list matches 1 run data modify storage ct:roles roles insert 0 value {id:517,name:voudon}
 
-tellraw @s [{"translate":"clocktower.prefix.generic","color":"yellow","bold":true},{"translate":"clocktower.notice.bag_created","color":"gray","bold":false}]
+tellraw @s [{"translate":"clocktower.prefix.generic","color":"yellow","bold":true},{"translate":"clocktower.notice.bag_created","color":"gray","bold":false, "with":[{"keybind":"key.chat"}]}]
 execute as @a run function ct:admin/setup/clear_variables

--- a/resources/datapack/required/ct/data/ct/function/loop/night.mcfunction
+++ b/resources/datapack/required/ct/data/ct/function/loop/night.mcfunction
@@ -10,7 +10,7 @@ execute if score growl game_data matches 1 if score current_day game_data matche
 execute as @a[scores={reveal_cd=139},tag=!spectator,tag=!storyteller] if score @s vc = @s id run function ct:start_game/roles/youare
 execute as @a[tag=!spectator,tag=!storyteller,scores={reveal_cd=1..}] if score @s vc = @s id run scoreboard players remove @s reveal_cd 1
 execute as @a[scores={reveal_cd=60}] run function ct:start_game/roles/announce
-tellraw @s[tag=!storyteller,tag=!spectator,scores={reveal_cd=1}] [{"text":"! ","color":"yellow","bold":true},{"text":"Press T to release your mouse, then hover over your character icon in the top left to see your ability.","color":"gray","bold":false}]
+tellraw @s[tag=!storyteller,tag=!spectator,scores={reveal_cd=1}] [{"translate":"clocktower.prefix.generic","color":"yellow","bold":true},{"translate":"clocktower.notice.hover_hint","color":"gray","bold":false, "with":[{"keybind":"key.chat"}]}]
 execute as @a at @s run function ct:loop/player/night
 function ct:util/timer/end
 

--- a/resources/datapack/required/ct/data/ct/function/loop/player/night.mcfunction
+++ b/resources/datapack/required/ct/data/ct/function/loop/player/night.mcfunction
@@ -1,8 +1,8 @@
-execute if score @s[tag=!storyteller,tag=!spectator,tag=universal_vc] vc = @s id run title @s actionbar [{text:"Everyone",color:green},{text:" can hear you. ",color:white},{text:"Press ENTER to toggle.",color:white}]
-execute if score @s[tag=!storyteller,tag=!spectator,tag=!universal_vc] vc = @s id run title @s actionbar [{text:"Only the Storyteller",color:red},{text:" can hear you. ",color:white},{text:"Press ENTER to toggle.",color:white}]
+execute if score @s[tag=!storyteller,tag=!spectator,tag=universal_vc] vc = @s id run title @s actionbar [{"translate":"clocktower.notice.night_chat.player.enabled","color":"white","bold":false,with:[{"keybind": "Toggle Night Voice Chat"}]}]
+execute if score @s[tag=!storyteller,tag=!spectator,tag=!universal_vc] vc = @s id run title @s actionbar [{"translate":"clocktower.notice.night_chat.player.disabled","color":"white","bold":false,with:[{"keybind": "Toggle Night Voice Chat"}]}]
 
-execute as @s[tag=storyteller,tag=universal_vc] unless entity @a[tag=!storyteller,tag=!spectator,scores={vc=0}] run title @s actionbar [{text:"Everyone",color:green},{text:" can hear you. ",color:white},{text:"Press ENTER to toggle.",color:white}]
-execute as @s[tag=storyteller,tag=!universal_vc] unless entity @a[tag=!storyteller,tag=!spectator,scores={vc=0}] run title @s actionbar [{text:"Only local players",color:red},{text:" can hear you. ",color:white},{text:"Press ENTER to toggle.",color:white}]
+execute as @s[tag=storyteller,tag=universal_vc] unless entity @a[tag=!storyteller,tag=!spectator,scores={vc=0}] run title @s actionbar [{"translate":"clocktower.notice.night_chat.storyteller.enabled","color":"white","bold":false,with:[{"keybind": "Toggle Night Voice Chat"}]}]
+execute as @s[tag=storyteller,tag=!universal_vc] unless entity @a[tag=!storyteller,tag=!spectator,scores={vc=0}] run title @s actionbar [{"translate":"clocktower.notice.night_chat.storyteller.disabled","color":"white","bold":false,with:[{"keybind": "Toggle Night Voice Chat"}]}]
 
-execute as @s[tag=spectator,tag=universal_vc] run title @s actionbar [{text:"Listening to ",color:white},{text:"night chat",color:green},{text:". ",color:white},{text:"Press ENTER to toggle.",color:white}]
-execute as @s[tag=spectator,tag=!universal_vc] run title @s actionbar [{text:"Listening to ",color:white},{text:"local players",color:red},{text:". ",color:white},{text:"Press ENTER to toggle.",color:white}]
+execute as @s[tag=spectator,tag=universal_vc] run title @s actionbar [{"translate":"clocktower.notice.night_chat.spectator.enabled","color":"white","bold":false,with:[{"keybind": "Toggle Night Voice Chat"}]}]
+execute as @s[tag=spectator,tag=!universal_vc] run title @s actionbar [{"translate":"clocktower.notice.night_chat.spectator.disabled","color":"white","bold":false,with:[{"keybind": "Toggle Night Voice Chat"}]}]

--- a/resources/resourcepack/required/Blood on the Clocktower/assets/minecraft/lang/en_us.json
+++ b/resources/resourcepack/required/Blood on the Clocktower/assets/minecraft/lang/en_us.json
@@ -166,8 +166,15 @@
     "clocktower.notice.tpchurch.player": "A mysterious force teleported you to the church.",
     "clocktower.notice.new_target": " has selected a new target.",
     "clocktower.notice.in_play": " is in play.",
-    "clocktower.notice.bag_created": "You've made a bag with the characters you selected. Press T and click \"Start Night 1\" in the top right to hand them out.",
+    "clocktower.notice.bag_created": "You've made a bag with the characters you selected. Press %s and click \"Start Night 1\" in the top right to hand them out.",
     "clocktower.notice.dev_mode": "Dev Mode is currently active. Make sure to run the package function and reload again before shipping.",
+    "clocktower.notice.hover_hint":"Press %s to release your mouse, then hover over your character icon in the top left to see your ability.",
+    "clocktower.notice.night_chat.storyteller.enabled": "§aEveryone§r can hear you. Press %s to toggle.",
+    "clocktower.notice.night_chat.storyteller.disabled": "§cOnly local players§r can hear you. Press %s to toggle.",
+    "clocktower.notice.night_chat.player.enabled": "§aEveryone§r can hear you. Press %s to toggle.",
+    "clocktower.notice.night_chat.player.disabled": "§cOnly the Storyteller§r can hear you. Press %s to toggle.",
+    "clocktower.notice.night_chat.spectator.enabled": "Listening to §anight chat§r. Press %s to toggle.",
+    "clocktower.notice.night_chat.spectator.disabled": "Listening to §alocal players§r. Press %s to toggle.",
     //
     // RANDOM STRINGS
     //


### PR DESCRIPTION
Remade this with a new PR for cleanliness:

> This changes the chat/actionbar messages that include keybinds to use the user's binds instead of an assumed default
> (this was annoying me when fixing something else so I made a quick fix and thought it was worthy of a tiny pr)
> 
> If this should target 1.6.1 instead lmk
> 
> Closes https://github.com/Sybillian/minecraft-botc/issues/177